### PR TITLE
Update vim cursor after dw

### DIFF
--- a/spyder_vim/vim_widget.py
+++ b/spyder_vim/vim_widget.py
@@ -143,6 +143,7 @@ class VimKeys(object):
                             repeat)
         editor.setTextCursor(cursor)
         editor.cut()
+        self._widget.update_vim_cursor()
 
     # %% Copy
     def yy(self, repeat):

--- a/spyder_vim/vim_widget.py
+++ b/spyder_vim/vim_widget.py
@@ -126,6 +126,7 @@ class VimKeys(object):
         cursor.movePosition(QTextCursor.Down, QTextCursor.KeepAnchor, repeat)
         editor.setTextCursor(cursor)
         editor.cut()
+        self._widget.update_vim_cursor()
 
     def D(self, repeat):
         editor = self._widget.editor()
@@ -135,6 +136,7 @@ class VimKeys(object):
                             repeat - 1)
         editor.setTextCursor(cursor)
         editor.cut()
+        self._widget.update_vim_cursor()
 
     def dw(self, repeat):
         editor = self._widget.editor()


### PR DESCRIPTION
After doing a 'dw', it's nice to still see the vim cursor.

Not sure if this is the best way to implement (read: there may be multiple occurrences where you want to update_vim_cursor, probably there will be more to follow but I wanted to be conservative to start with), feedback welcome :)